### PR TITLE
Update libraries in mix.lock

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,6 @@ defmodule Scrivener.Headers.Mixfile do
   defp deps do
     [{:plug, "~> 1.1", optional: true},
      {:scrivener, "~> 2.0"},
-     {:earmark, "~> 1.0", only: :dev},
-     {:ex_doc, ">= 0.2.0", only: :dev}]
+     {:ex_doc, "~> 0.13.0", only: :dev}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.7.2", "c24bd9efdace906c23c943280a3d29c15e649e4c0eeca92f6ee35723f44691a7", [:mix], []},
-  "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
-  "scrivener": {:hex, :scrivener, "2.0.0", "38e59a1c37e989c40a22c019da245a86b257182aee45a074292c9038fab39678", [:mix], []}}
+  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "scrivener": {:hex, :scrivener, "2.1.0", "ee6ffed875001c81c27cac6074723790f12591da36a3e94f1db5ce1c9bd931e8", [:mix], []}}


### PR DESCRIPTION
SInce scrivener was updated to 2.1.0, I updated it in mix.lock and checked all tests pass.

And I updated ex_docs and now we can publish documents in better visual.
If you're ok, please `mix docs` before `mix hex.publish`.