### PR TITLE
added 2 more fields to help with pagination as well as normalized key…

### DIFF
--- a/lib/scrivener/headers.ex
+++ b/lib/scrivener/headers.ex
@@ -33,6 +33,8 @@ defmodule Scrivener.Headers do
     |> put_resp_header("link", build_link_header(uri, page))
     |> put_resp_header("total", Integer.to_string(page.total_entries))
     |> put_resp_header("per-page", Integer.to_string(page.page_size))
+    |> put_resp_header("total-pages", Integer.to_string(page.total_pages))
+    |> put_resp_header("page-number", Integer.to_string(page.page_number))
   end
 
   @spec build_link_header(URI.t, Scrivener.Page.t) :: String.t

--- a/test/scrivener/headers_test.exs
+++ b/test/scrivener/headers_test.exs
@@ -22,6 +22,8 @@ defmodule Scrivener.HeadersTests do
 
     assert headers["total"] == "50"
     assert headers["per-page"] == "10"
+    assert headers["total-pages"] == "5"
+    assert headers["page-number"] == "3"
     links = String.split(headers["link"], ", ")
     assert ~s(<http://www.example.com/test?foo=bar&page=1>; rel="first") in links
     assert ~s(<http://www.example.com/test?foo=bar&page=5>; rel="last") in links


### PR DESCRIPTION
It seems the main mix spits out 4 keys and I felt we should just be replicating this to keep things consistent.

Here's what scrivener gives.
page_number: 1
page_size: 25
total_entries: 4
total_pages: 1

Now scrivener headers will give the following headers:

page-number: 1
page-size: 25
total-entries: 4
total-pages: 1